### PR TITLE
Fix invalid typescript interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface Cache = {
+interface Cache {
   keys: Array<any>,
   size: number,
   values: Array<any>


### PR DESCRIPTION
After upgrading typescript this "=" is breaking the typings file. 

Tested using the [Typescript playground](http://www.typescriptlang.org/play/) and my local setup using Typescript 2.8.1