### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,4 @@ interface Options {
 
 type Fn = (...args: any[]) => any;
 
-declare function memoize<T extends Fn>(fn: T, options?: Options): T;
-
-export default memoize;
+export default function memoize<T extends Fn>(fn: T, options?: Options): T;


### PR DESCRIPTION
Newer versions of the typescript complier are throwing "error TS1036: Statements are not allowed in ambient contexts." errors