### PR TITLE
fix issue where getKeyIndex failed when no keys were in the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # micro-memoize CHANGELOG
 
+## 4.0.5
+
+- Fix failure when `getKeyIndex` is used and no keys are in the cache
+
 ## 4.0.4
 
 - Use `.pop()` to cap cache to `maxSize` when possible (slight performance improvement)

--- a/__tests__/Cache.ts
+++ b/__tests__/Cache.ts
@@ -64,6 +64,18 @@ describe('create cache', () => {
 
 describe('cache methods', () => {
   describe('getKeyIndex', () => {
+    it('will return -1 if no keys exist', () => {
+      const isEqual = (o1: any, o2: any) => o1 === o2;
+
+      const cache = new Cache({ isEqual });
+
+      const keyToMatch = ['key'];
+
+      const result = cache.getKeyIndex(keyToMatch);
+
+      expect(result).toEqual(-1);
+    });
+
     it('will return the index of the match found', () => {
       const isEqual = (o1: any, o2: any) => o1 === o2;
 
@@ -100,6 +112,18 @@ describe('cache methods', () => {
       cache.keys = [['key']];
 
       const keyToMatch = ['other key'];
+
+      const result = cache.getKeyIndex(keyToMatch);
+
+      expect(result).toEqual(-1);
+    });
+
+    it('will return -1 if no keys exist with larger maxSize', () => {
+      const isEqual = (o1: any, o2: any) => o1 === o2;
+
+      const cache = new Cache({ isEqual, maxSize: 2 });
+
+      const keyToMatch = ['key'];
 
       const result = cache.getKeyIndex(keyToMatch);
 
@@ -227,6 +251,28 @@ describe('cache methods', () => {
       const result = cache.getKeyIndex(keyToMatch);
 
       expect(result).toEqual(1);
+    });
+
+    it('will return -1 if the isMatchingKey method is passed and there are no keys', () => {
+      const isEqual = (o1: any, o2: any) => o1 === o2;
+      const isMatchingKey = (o1: any, o2: any) => {
+        const existingKey = o1[0];
+        const key = o2[0];
+
+        return (
+          existingKey.hasOwnProperty('foo') &&
+          key.hasOwnProperty('foo') &&
+          (existingKey.bar === 'bar' || key.bar === 'baz')
+        );
+      };
+
+      const cache = new Cache({ isEqual, isMatchingKey });
+
+      const keyToMatch = ['key'];
+
+      const result = cache.getKeyIndex(keyToMatch);
+
+      expect(result).toEqual(-1);
     });
 
     it('will return -1 if the isMatchingKey method is passed and no match is found', () => {

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -70,14 +70,17 @@ export class Cache {
     const { isMatchingKey, maxSize } = this.options;
 
     const { keys } = this;
+    const keysLength = keys.length;
+
+    if (!keysLength) {
+      return -1;
+    }
 
     if (isMatchingKey(keys[0], keyToMatch)) {
       return 0;
     }
 
     if (maxSize > 1) {
-      const keysLength = keys.length;
-
       for (let index = 1; index < keysLength; index++) {
         if (isMatchingKey(keys[index], keyToMatch)) {
           return index;
@@ -102,6 +105,10 @@ export class Cache {
 
     const { keys } = this;
     const keysLength = keys.length;
+
+    if (!keysLength) {
+      return -1;
+    }
 
     const keyLength = keyToMatch.length;
 
@@ -139,16 +146,22 @@ export class Cache {
    * @returns the index of the matching key, or -1
    */
   _getKeyIndexForSingle(keyToMatch: MicroMemoize.Key) {
-    const existingKey = this.keys[0];
-    const keyLength = existingKey.length;
+    const { keys } = this;
 
-    if (keyToMatch.length !== keyLength) {
+    if (!keys.length) {
+      return -1;
+    }
+
+    const existingKey = keys[0];
+    const { length } = existingKey;
+
+    if (keyToMatch.length !== length) {
       return -1;
     }
 
     const { isEqual } = this.options;
 
-    for (let index = 0; index < keyLength; index++) {
+    for (let index = 0; index < length; index++) {
       if (!isEqual(existingKey[index], keyToMatch[index])) {
         return -1;
       }


### PR DESCRIPTION
Fix issue where if `getKeyIndex` is used directly and there are no keys in the cache, it fails.