### PR TITLE
Default generics for pass-through on explicit types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,9 @@
       "node": {
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
+    },
+    "react": {
+      "version": "detect"
     }
   },
   "rules": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # micro-memoize CHANGELOG
 
+## 4.0.13
+
+- [#87](https://github.com/planttheidea/micro-memoize/pull/87) - Default generic values for exposed types, to avoid unintentional breaking changes from [#85](https://github.com/planttheidea/micro-memoize/pull/85)
+
 ## 4.0.12
 
 - [#84](https://github.com/planttheidea/micro-memoize/pull/84) - Fix inferred typing of memoized function

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export declare namespace MicroMemoize {
 
   export type RawKey = Key | IArguments;
 
-  export type Cache<Fn extends AnyFn> = import('./src/Cache').Cache<Fn>;
+  export type Cache<Fn extends AnyFn = AnyFn> = import('./src/Cache').Cache<Fn>;
 
   export type EqualityComparator = (object1: any, object2: any) => boolean;
 
@@ -27,7 +27,7 @@ export declare namespace MicroMemoize {
 
   export type KeyIndexGetter = (keyToMatch: RawKey) => number;
 
-  export type StandardOptions<Fn extends AnyFn> = {
+  export type StandardOptions<Fn extends AnyFn = AnyFn> = {
     isEqual?: EqualityComparator;
     isMatchingKey?: MatchingKeyComparator;
     isPromise?: boolean;
@@ -38,14 +38,15 @@ export declare namespace MicroMemoize {
     transformKey?: KeyTransformer;
   };
 
-  export type Options<Fn extends AnyFn> = StandardOptions<Fn> & Dictionary<any>;
-  export type NormalizedOptions<Fn extends AnyFn> = Options<Fn> & {
+  export type Options<Fn extends AnyFn = AnyFn> = StandardOptions<Fn> &
+    Dictionary<any>;
+  export type NormalizedOptions<Fn extends AnyFn = AnyFn> = Options<Fn> & {
     isEqual: EqualityComparator;
     isPromise: boolean;
     maxSize: number;
   };
 
-  export type Memoized<Fn extends AnyFn> = Fn &
+  export type Memoized<Fn extends AnyFn = AnyFn> = Fn &
     Dictionary<any> & {
       cache: Cache<Fn>;
       fn: Fn;

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export declare namespace MicroMemoize {
 
   export type MatchingKeyComparator = (key1: Key, key2: RawKey) => boolean;
 
-  export type CacheModifiedHandler<Fn extends AnyFn> = (
+  export type CacheModifiedHandler<Fn extends AnyFn = AnyFn> = (
     cache: Cache<Fn>,
     options: NormalizedOptions<Fn>,
     memoized: Fn,


### PR DESCRIPTION
This surfaced in [a `moize` issue](https://github.com/planttheidea/moize/issues/184), but can also impact consumers of the library directly as an unintentional breaking change.