### PR TITLE
Publish only necessary items

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,9 +4,15 @@
 .idea
 .npmignore
 .nyc_output
+__tests__
+.prettierrc.js
+.release-it*
+benchmarks
 coverage
 DEV_ONLY
+es-to-mjs.js
+jest.config.js
 node_modules
+rollup.config.js
 src
-test
 webpack

--- a/.npmignore
+++ b/.npmignore
@@ -15,4 +15,5 @@ jest.config.js
 node_modules
 rollup.config.js
 src
+tsconfig.json
 webpack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # micro-memoize CHANGELOG
 
+## 4.1.1
+
+- [#102](https://github.com/planttheidea/micro-memoize/pull/102) - avoid publishing development-only files for less `node_modules` bloat
+
 ## 4.1.0
 
 #### Enhancements

--- a/package.json
+++ b/package.json
@@ -102,5 +102,5 @@
   },
   "sideEffects": false,
   "types": "./index.d.ts",
-  "version": "4.1.1-beta.0"
+  "version": "4.1.1-beta.1"
 }

--- a/package.json
+++ b/package.json
@@ -102,5 +102,5 @@
   },
   "sideEffects": false,
   "types": "./index.d.ts",
-  "version": "4.1.0"
+  "version": "4.1.1-beta.0"
 }


### PR DESCRIPTION
## Reason for change
Continuation of #97 , where I realize several additional development-only pieces are included in the package publish.

## Change
Remove all development-only aspects and only publish the necessary files.