### PR TITLE
Add `exports` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "license": "MIT",
   "main": "dist/micro-memoize.cjs.js",
   "module": "dist/micro-memoize.esm.js",
+  "exports": "./mjs/index.mjs",
   "name": "micro-memoize",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/planttheidea/micro-memoize/issues/104

NodeJS in ESM mode, and Typescript under `Node16` resolution do not read the `module` property of `package.json`. This leads to errors using micro-memoize with `Node16` resolution in Typescript as it doesn't think the types match the CommonJS implementation (even though this does work in most bundlers and Node today). You can see the [error on this debug page](https://arethetypeswrong.github.io/?p=micro-memoize%404.1.2).

This PR adds the `exports` field that points to the mjs version of the library, with adjacent `index.d.ts` satisfying both Node and TS.

You may be able to view [this modification running here](https://stackblitz.com/edit/vitejs-vite-tyb3tz?file=tsconfig.json,node_modules%2Fmicro-memoize%2Fpackage.json,src%2Fmain.ts,package.json,README.md&terminal=dev), and see Typescript's resolution process by running `npm run build`:

```
======== Resolving module 'micro-memoize' from '/home/projects/vitejs-vite-tyb3tz/src/main.ts'. ========
Explicitly specified module resolution kind: 'Node16'.
Resolving in ESM mode with conditions 'import', 'types', 'node'.
File '/home/projects/vitejs-vite-tyb3tz/src/package.json' does not exist according to earlier cached lookups.
File '/home/projects/vitejs-vite-tyb3tz/package.json' exists according to earlier cached lookups.
Loading module 'micro-memoize' from 'node_modules' folder, target file types: TypeScript, JavaScript, Declaration.
Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
Directory '/home/projects/vitejs-vite-tyb3tz/src/node_modules' does not exist, skipping all lookups in it.
Found 'package.json' at '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/package.json'.
Using 'exports' subpath '.' with target './mjs/index.mjs'.
File name '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/mjs/index.mjs' has a '.mjs' extension - stripping it.
File '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/mjs/index.mts' does not exist.
File '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/mjs/index.d.mts' exists - use it as a name resolution result.
'package.json' does not have a 'peerDependencies' field.
Resolving real path for '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/mjs/index.d.mts', result '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/mjs/index.d.mts'.
======== Module name 'micro-memoize' was successfully resolved to '/home/projects/vitejs-vite-tyb3tz/node_modules/micro-memoize/mjs/index.d.mts' with Package ID 'micro-memoize/mjs/index.d.mts@4.1.2'. ========
```