### PR TITLE
[Fix] Ensure type narrowing is maintained

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,16 +11,17 @@ export const memoize: Memoize = function memoize<Fn extends (...args: any[]) => 
   fn: Fn | Memoized<Fn, Opts>,
   options: Opts = {} as Opts,
 ): Memoized<Fn, Opts> {
-  if (typeof fn !== 'function') {
-    throw new TypeError(`Expected first parameter to be function; received ${typeof fn}`);
-  }
-
   if (isMemoized(fn)) {
     return memoize(fn.fn, Object.assign({}, fn.options, options));
   }
 
-  const memoized: Memoized<Fn, Opts> = function memoized(this: any, ...args: Parameters<Fn>) {
-    const cache = memoized.cache;
+  if (typeof fn !== 'function') {
+    throw new TypeError(`Expected first parameter to be function; received ${typeof fn}`);
+  }
+
+  const cache = new Cache(options);
+
+  const memoized = function memoized(this: any, ...args: Parameters<Fn>) {
     const key: Key = cache.k ? cache.k(args) : args;
 
     let node = cache.g(key);
@@ -41,9 +42,7 @@ export const memoize: Memoize = function memoize<Fn extends (...args: any[]) => 
     }
 
     return node.v;
-  };
-
-  const cache = new Cache(options);
+  } as Memoized<Fn, Opts>;
 
   memoized.cache = cache;
   memoized.expirationManager = getExpirationManager(cache, options);

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -291,9 +291,7 @@ export interface CacheSnapshot<Fn extends (...args: any[]) => any> {
 /**
  * Method that has been memoized via `micro-memoize`.
  */
-export interface Memoized<Fn extends (...args: any[]) => any, Opts extends Options<Fn>> {
-  (...args: Parameters<Fn>): ReturnType<Fn>;
-
+export type Memoized<Fn extends (...args: any[]) => any, Opts extends Options<Fn>> = Fn & {
   /**
    * The cache used for the memoized method.
    */
@@ -320,7 +318,7 @@ export interface Memoized<Fn extends (...args: any[]) => any, Opts extends Optio
    * is set.
    */
   statsManager: StatsManager<Fn> | undefined;
-}
+};
 
 export interface Memoize {
   <Fn extends Memoized<(...args: any[]) => any, Options<(...args: any[]) => any>>>(fn: Fn): Memoized<Fn, Fn['options']>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,11 @@
-import type { Memoized } from './internalTypes.js';
+import type { Memoized, Options } from './internalTypes.js';
 
 /**
  * Whether the value passed is a memoized function via `micro-memoize`.
  */
-export function isMemoized(fn: any): fn is Memoized<any, any> {
+export function isMemoized<Fn extends (...args: any) => any, Opts extends Options<Fn>>(
+  fn: any,
+): fn is Memoized<Fn, Opts> {
   return typeof fn === 'function' && fn.isMemoized;
 }
 


### PR DESCRIPTION
## Resaon for change

When a function is memoized that has multple types possible based on generics, the type returned should be based on the value passed:

```ts
const fn = <T extends object | string>(v: T): T => v;
const memoFn = memoize(fn);

const result = fn('123');
// result should be a string
```

Instead, the above was showing `object | string`, all possible generic types. This was working as expected in v4.

## Change

Tweak the types to ensure that the types are correctly maintained.

This involved a change in the types, where in v4 the type was an intersection of the function and the additional properties on the memoized result:

```ts
type Memoized<Fn> = Fn & {...}
```

In v5 this changed to an interface with the function explicitly set:

```ts
interface Memoized<Fn> {
  (...args: Parameters<Fn>): ReturnType<Fn>;
  ...
}
```

By reverting it to a type intersection, the narrowing was restored. Resolves #126 