### PR TITLE
[Fix] update `cli-table2` to `cli-table3` to fix security vuln

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -2,7 +2,7 @@ import lodashDeepEqual from 'lodash/isEqual.js';
 import lodashMemoize from 'lodash/memoize.js';
 import orderBy from 'lodash/orderBy.js';
 import { Bench } from 'tinybench';
-import Table from 'cli-table2';
+import Table from 'cli-table3';
 
 import { addOsmaniMemoize } from './addy-osmani.js';
 import fastMemoize from 'fast-memoize';
@@ -10,7 +10,7 @@ import lru from 'lru-memoize';
 import mem from 'mem';
 import memoizee from 'memoizee';
 import memoizerific from 'memoizerific';
-import { memoize } from '../dist/esm/index.mjs';
+import { memoize } from '../dist/es/index.mjs';
 import { memoizeWith as ramdaMemoize } from 'ramda';
 import { memoize as underscoreMemoize } from 'underscore';
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@typescript-eslint/parser": "^8.47.0",
     "@vitest/coverage-v8": "^4.0.14",
     "bluebird": "^3.7.2",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.6.5",
     "eslint": "^9.39.1",
     "eslint-plugin-import": "^2.32.0",
     "fast-copy": "^4.0.0",
@@ -97,7 +97,7 @@
     "url": "git+https://github.com/planttheidea/micro-memoize.git"
   },
   "scripts": {
-    "benchmark": "npm run clean:es && npm run build:esm && node benchmark/index.js",
+    "benchmark": "npm run build && node benchmark/index.js",
     "build": "npm run clean && npm run build:dist && npm run build:types",
     "build:dist": "NODE_ENV=production rollup -c config/rollup.config.js",
     "build:types": "pti fix-types -l dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@colors/colors@npm:1.5.0"
+  checksum: 10c0/eb42729851adca56d19a08e48d5a1e95efd2a32c55ae0323de8119052be0510d4b7a1611f2abcbf28c044a6c11e6b7d38f99fccdad7429300c37a8ea5fb95b44
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/aix-ppc64@npm:0.25.12"
@@ -1665,13 +1672,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "ansi-regex@npm:2.1.1"
-  checksum: 10c0/78cebaf50bce2cb96341a7230adf28d804611da3ce6bf338efa7b72f06cc6ff648e29f80cd95e582617ba58d5fdbec38abfeed3500a98bce8381a9daec7c548b
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -2147,17 +2147,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-table2@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "cli-table2@npm:0.2.0"
+"cli-table3@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "cli-table3@npm:0.6.5"
   dependencies:
-    colors: "npm:^1.1.2"
-    lodash: "npm:^3.10.1"
-    string-width: "npm:^1.0.1"
+    "@colors/colors": "npm:1.5.0"
+    string-width: "npm:^4.2.0"
   dependenciesMeta:
-    colors:
+    "@colors/colors":
       optional: true
-  checksum: 10c0/37b823022f04a5023bc9bcf648ca66dc8d675403d20d255b68600b8076e69f1c453bd193afd02b35e4de2c6523ad04bd92efd3c4d252950d5ea52936f66e76c8
+  checksum: 10c0/d7cc9ed12212ae68241cc7a3133c52b844113b17856e11f4f81308acc3febcea7cc9fd298e70933e294dd642866b29fd5d113c2c098948701d0c35f09455de78
   languageName: node
   linkType: hard
 
@@ -2179,13 +2178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-point-at@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "code-point-at@npm:1.1.0"
-  checksum: 10c0/33f6b234084e46e6e369b6f0b07949392651b4dde70fc6a592a8d3dafa08d5bb32e3981a02f31f6fc323a26bc03a4c063a9d56834848695bda7611c2417ea2e6
-  languageName: node
-  linkType: hard
-
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
@@ -2199,13 +2191,6 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
-  languageName: node
-  linkType: hard
-
-"colors@npm:^1.1.2":
-  version: 1.4.0
-  resolution: "colors@npm:1.4.0"
-  checksum: 10c0/9af357c019da3c5a098a301cf64e3799d27549d8f185d86f79af23069e4f4303110d115da98483519331f6fb71c8568d5688fa1c6523600044fd4a54e97c4efb
   languageName: node
   linkType: hard
 
@@ -3909,15 +3894,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-fullwidth-code-point@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-fullwidth-code-point@npm:1.0.0"
-  dependencies:
-    number-is-nan: "npm:^1.0.0"
-  checksum: 10c0/12acfcf16142f2d431bf6af25d68569d3198e81b9799b4ae41058247aafcc666b0127d64384ea28e67a746372611fcbe9b802f69175287aba466da3eddd5ba0f
-  languageName: node
-  linkType: hard
-
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
@@ -4403,13 +4379,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^3.10.1":
-  version: 3.10.1
-  resolution: "lodash@npm:3.10.1"
-  checksum: 10c0/f5f6d3d87503c3f1db27d49b30a00bb38dc1bd9de716c5febe8970259cc7b447149a0e320452ccaf5996a7a4abd63d94df341bb91bd8d336584ad518d8eab144
-  languageName: node
-  linkType: hard
-
 "lodash@npm:^4.15.0, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
@@ -4627,7 +4596,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.47.0"
     "@vitest/coverage-v8": "npm:^4.0.14"
     bluebird: "npm:^3.7.2"
-    cli-table2: "npm:^0.2.0"
+    cli-table3: "npm:^0.6.5"
     eslint: "npm:^9.39.1"
     eslint-plugin-import: "npm:^2.32.0"
     fast-copy: "npm:^4.0.0"
@@ -4932,13 +4901,6 @@ __metadata:
     path-key: "npm:^4.0.0"
     unicorn-magic: "npm:^0.3.0"
   checksum: 10c0/b223c8a0dcd608abf95363ea5c3c0ccc3cd877daf0102eaf1b0f2390d6858d8337fbb7c443af2403b067a7d2c116d10691ecd22ab3c5273c44da1ff8d07753bd
-  languageName: node
-  linkType: hard
-
-"number-is-nan@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "number-is-nan@npm:1.0.1"
-  checksum: 10c0/cb97149006acc5cd512c13c1838223abdf202e76ddfa059c5e8e7507aff2c3a78cd19057516885a2f6f5b576543dc4f7b6f3c997cc7df53ae26c260855466df5
   languageName: node
   linkType: hard
 
@@ -6123,18 +6085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "string-width@npm:1.0.2"
-  dependencies:
-    code-point-at: "npm:^1.0.0"
-    is-fullwidth-code-point: "npm:^1.0.0"
-    strip-ansi: "npm:^3.0.0"
-  checksum: 10c0/c558438baed23a9ab9370bb6a939acbdb2b2ffc517838d651aad0f5b2b674fb85d460d9b1d0b6a4c210dffd09e3235222d89a5bd4c0c1587f78b2bb7bc00c65e
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^4.1.0":
+"string-width@npm:^4.1.0, string-width@npm:^4.2.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -6232,15 +6183,6 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/d53af1899959e53c83b64a5fd120be93e067da740e7e75acb433849aa640782fb6c7d4cd5b84c954c84413745a3764df135a8afeb22908b86a835290788d8366
-  languageName: node
-  linkType: hard
-
-"strip-ansi@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "strip-ansi@npm:3.0.1"
-  dependencies:
-    ansi-regex: "npm:^2.0.0"
-  checksum: 10c0/f6e7fbe8e700105dccf7102eae20e4f03477537c74b286fd22cfc970f139002ed6f0d9c10d0e21aa9ed9245e0fa3c9275930e8795c5b947da136e4ecb644a70f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Reason for change

There has long been a security vulnerability with the repo related to the inclusion of a dated version of `lodash` as a transitive dependency of `cli-table2` used in benchmarking. This can be fixed by the drop-in replacement `cli-table3`.

## Change

Update to `cli-table3`, which removes the transitive dependency.