### PR TITLE
[Bugfix] Gap audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # micro-memoize CHANGELOG
 
+## 5.2.0
+
+### Enhancements
+
+- Specialized handling for the default `maxSize` of 1, which has no list to search or reorder
+- Avoid walking the cache on `clear()` when no entry can outlive it
+- Added `dispose()` to the stats manager, to deregister a profile and release the cache it retains
+
+### Fixes
+
+- Fix cleared entries being restored when an `async` entry rejects after the `clear()`
+- Fix `clearStats()` unregistering profiles instead of resetting their counts
+- Fix memoized methods sharing a `statsName` replacing one another instead of being numbered (`foo (2)`)
+
 ## 5.1.2
 
 - [#157](https://github.com/planttheidea/micro-memoize/pull/157) - Resolve TS2846 and TS2503 errors from type

--- a/README.md
+++ b/README.md
@@ -791,20 +791,20 @@ stopCollectingStats();
 
 ## Benchmarks
 
-All values provided are the number of operations per second (ops/sec) calculated by the
-[Benchmark suite](https://benchmarkjs.com/). Note that `underscore`, `lodash`, and `ramda` do not support
+All values provided are the number of operations per second (ops/sec) calculated by
+[tinybench](https://github.com/tinylibs/tinybench). Note that `underscore`, `lodash`, and `ramda` do not support
 mulitple-parameter memoization (which is where `micro-memoize` really shines), so they are not included in those
 benchmarks.
 
-Benchmarks was performed on an i9 16-core Linux laptop with 64GB of memory using NodeJS version `24.11.0`. The default
+Benchmarks was performed on an i9 16-core Linux laptop with 64GB of memory using NodeJS version `24.15.0`. The default
 configuration of each library was tested with a fibonacci calculation based on the following parameters:
 
-- Single primitive = `35`
-- Single array = `[35]`
-- Single object = `{ number: 35 }`
-- Multiple primitives = `35, true`
-- Multiple arrays = `[35], [true]`
-- Multiple objects = `{ number: 35 }, { isComplete: true }`
+- Single primitive = `25`
+- Single array = `[25]`
+- Single object = `{ number: 25 }`
+- Multiple primitives = `25, false`
+- Multiple arrays = `[25], [false]`
+- Multiple objects = `{ number: 25 }, { isComplete: false }`
 
 **NOTE**: Not all libraries tested support multiple parameters out of the box, but support the ability to pass a custom
 `resolver`. Because these often need to resolve to a string value,
@@ -817,25 +817,25 @@ is what is used when needed.
 ┌───────────────┬─────────────────┐
 │ Name          │ Ops / sec       │
 ├───────────────┼─────────────────┤
-│ micro-memoize │ 19223652.896122 │
+│ micro-memoize │ 19878405.869513 │
 ├───────────────┼─────────────────┤
-│ lru-memoize   │ 18832637.003931 │
+│ lru-memoize   │ 19502821.957062 │
 ├───────────────┼─────────────────┤
-│ fast-memoize  │ 18656534.751361 │
+│ fast-memoize  │ 19490029.447615 │
 ├───────────────┼─────────────────┤
-│ mem           │ 18002171.563837 │
+│ mem           │ 19279636.934769 │
 ├───────────────┼─────────────────┤
-│ lodash        │ 16593919.372016 │
+│ lodash        │ 15736616.801462 │
 ├───────────────┼─────────────────┤
-│ ramda         │ 15005783.713612 │
+│ ramda         │ 15687681.482776 │
 ├───────────────┼─────────────────┤
-│ addy osmani   │ 14595725.136778 │
+│ memoizee      │ 14749369.228334 │
 ├───────────────┼─────────────────┤
-│ underscore    │ 14394123.608684 │
+│ addy osmani   │ 14138487.10261  │
 ├───────────────┼─────────────────┤
-│ memoizee      │ 14143422.526051 │
+│ underscore    │ 13865374.036187 │
 ├───────────────┼─────────────────┤
-│ memoizerific  │ 9098305.800331  │
+│ memoizerific  │ 9199632.446672  │
 └───────────────┴─────────────────┘
 Fastest was "micro-memoize".
 
@@ -847,27 +847,28 @@ Fastest was "micro-memoize".
 ┌───────────────┬─────────────────┐
 │ Name          │ Ops / sec       │
 ├───────────────┼─────────────────┤
-│ micro-memoize │ 17778297.542508 │
+│ micro-memoize │ 18207906.508748 │
 ├───────────────┼─────────────────┤
-│ lodash        │ 16538329.518316 │
+│ lodash        │ 17089753.632004 │
 ├───────────────┼─────────────────┤
-│ lru-memoize   │ 15486317.927651 │
+│ lru-memoize   │ 16124168.757351 │
 ├───────────────┼─────────────────┤
-│ memoizee      │ 12094740.371154 │
+│ memoizee      │ 12625929.637213 │
 ├───────────────┼─────────────────┤
-│ memoizerific  │ 8539559.392909  │
+│ memoizerific  │ 9069719.223337  │
 ├───────────────┼─────────────────┤
-│ mem           │ 5084143.134978  │
+│ mem           │ 5755070.921705  │
 ├───────────────┼─────────────────┤
-│ ramda         │ 4779283.1256    │
+│ ramda         │ 5276088.346025  │
 ├───────────────┼─────────────────┤
-│ underscore    │ 4536871.295139  │
+│ underscore    │ 4993058.359933  │
 ├───────────────┼─────────────────┤
-│ addy osmani   │ 3930939.284558  │
+│ addy osmani   │ 4441016.626791  │
 ├───────────────┼─────────────────┤
-│ fast-memoize  │ 2280509.909947  │
+│ fast-memoize  │ 2956249.282323  │
 └───────────────┴─────────────────┘
 Fastest was "micro-memoize".
+
 ```
 
 ### Single object parameter
@@ -876,27 +877,28 @@ Fastest was "micro-memoize".
 ┌───────────────┬─────────────────┐
 │ Name          │ Ops / sec       │
 ├───────────────┼─────────────────┤
-│ micro-memoize │ 17660028.460248 │
+│ micro-memoize │ 17990445.065827 │
 ├───────────────┼─────────────────┤
-│ lodash        │ 16156245.220626 │
+│ lru-memoize   │ 16263269.18489  │
 ├───────────────┼─────────────────┤
-│ lru-memoize   │ 15870878.729231 │
+│ lodash        │ 16158739.12453  │
 ├───────────────┼─────────────────┤
-│ memoizee      │ 12282231.140112 │
+│ memoizee      │ 12375358.726362 │
 ├───────────────┼─────────────────┤
-│ memoizerific  │ 8673522.519546  │
+│ memoizerific  │ 8839399.636506  │
 ├───────────────┼─────────────────┤
-│ mem           │ 3990242.123108  │
+│ mem           │ 4438933.93951   │
 ├───────────────┼─────────────────┤
-│ ramda         │ 3740951.604329  │
+│ ramda         │ 4075165.112409  │
 ├───────────────┼─────────────────┤
-│ underscore    │ 3610838.023906  │
+│ underscore    │ 3951068.346673  │
 ├───────────────┼─────────────────┤
-│ addy osmani   │ 3091088.143196  │
+│ addy osmani   │ 3355307.945937  │
 ├───────────────┼─────────────────┤
-│ fast-memoize  │ 2037255.509585  │
+│ fast-memoize  │ 2557749.132062  │
 └───────────────┴─────────────────┘
 Fastest was "micro-memoize".
+
 ```
 
 ### Multiple primitive parameters
@@ -905,27 +907,28 @@ Fastest was "micro-memoize".
 ┌───────────────┬─────────────────┐
 │ Name          │ Ops / sec       │
 ├───────────────┼─────────────────┤
-│ micro-memoize │ 15890715.277889 │
+│ micro-memoize │ 16661302.548879 │
 ├───────────────┼─────────────────┤
-│ lru-memoize   │ 14795822.850331 │
+│ lru-memoize   │ 14879531.883346 │
 ├───────────────┼─────────────────┤
-│ memoizee      │ 8878241.434757  │
+│ memoizee      │ 9366968.363155  │
 ├───────────────┼─────────────────┤
-│ memoizerific  │ 6746446.702835  │
+│ memoizerific  │ 7445095.654414  │
 ├───────────────┼─────────────────┤
-│ addy osmani   │ 5088726.104365  │
+│ mem           │ 5460720.585562  │
 ├───────────────┼─────────────────┤
-│ mem           │ 4919428.914271  │
+│ addy osmani   │ 4903377.822876  │
 ├───────────────┼─────────────────┤
-│ ramda         │ 3931584.638274  │
+│ ramda         │ 4207163.662307  │
 ├───────────────┼─────────────────┤
-│ underscore    │ 3787236.410261  │
+│ underscore    │ 4113846.258468  │
 ├───────────────┼─────────────────┤
-│ lodash        │ 3521399.9522    │
+│ lodash        │ 3889607.988249  │
 ├───────────────┼─────────────────┤
-│ fast-memoize  │ 1921167.148268  │
+│ fast-memoize  │ 2248150.573838  │
 └───────────────┴─────────────────┘
 Fastest was "micro-memoize".
+
 ```
 
 ### Multiple array parameters
@@ -934,27 +937,28 @@ Fastest was "micro-memoize".
 ┌───────────────┬─────────────────┐
 │ Name          │ Ops / sec       │
 ├───────────────┼─────────────────┤
-│ micro-memoize │ 16477581.429235 │
+│ micro-memoize │ 16668684.33111  │
 ├───────────────┼─────────────────┤
-│ lru-memoize   │ 15973386.171668 │
+│ lru-memoize   │ 15782769.870912 │
 ├───────────────┼─────────────────┤
-│ memoizee      │ 8916765.084082  │
+│ memoizee      │ 9092493.003699  │
 ├───────────────┼─────────────────┤
-│ memoizerific  │ 7394462.762389  │
+│ memoizerific  │ 7768681.275842  │
 ├───────────────┼─────────────────┤
-│ mem           │ 4230286.398649  │
+│ mem           │ 4611769.035687  │
 ├───────────────┼─────────────────┤
-│ ramda         │ 3424812.638986  │
+│ ramda         │ 3844524.310138  │
 ├───────────────┼─────────────────┤
-│ underscore    │ 3271019.504488  │
+│ underscore    │ 3544635.721687  │
 ├───────────────┼─────────────────┤
-│ lodash        │ 3058024.57579   │
+│ lodash        │ 3443323.982287  │
 ├───────────────┼─────────────────┤
-│ addy osmani   │ 2556872.10781   │
+│ addy osmani   │ 2732158.515422  │
 ├───────────────┼─────────────────┤
-│ fast-memoize  │ 1664942.513511  │
+│ fast-memoize  │ 2071762.315914  │
 └───────────────┴─────────────────┘
 Fastest was "micro-memoize".
+
 ```
 
 ### Multiple object parameters
@@ -963,27 +967,28 @@ Fastest was "micro-memoize".
 ┌───────────────┬─────────────────┐
 │ Name          │ Ops / sec       │
 ├───────────────┼─────────────────┤
-│ micro-memoize │ 16816183.60597  │
+│ micro-memoize │ 14369200.463018 │
 ├───────────────┼─────────────────┤
-│ lru-memoize   │ 15847710.978627 │
+│ lru-memoize   │ 14333399.949079 │
 ├───────────────┼─────────────────┤
-│ memoizee      │ 8963861.306564  │
+│ memoizee      │ 8752485.371029  │
 ├───────────────┼─────────────────┤
-│ memoizerific  │ 7279084.235795  │
+│ memoizerific  │ 6903317.093568  │
 ├───────────────┼─────────────────┤
-│ mem           │ 2891756.11455   │
+│ mem           │ 3005085.159899  │
 ├───────────────┼─────────────────┤
-│ ramda         │ 2562787.384413  │
+│ lodash        │ 2624397.394368  │
 ├───────────────┼─────────────────┤
-│ underscore    │ 2508806.688495  │
+│ underscore    │ 2385132.287579  │
 ├───────────────┼─────────────────┤
-│ lodash        │ 2413141.440839  │
+│ ramda         │ 2372659.444672  │
 ├───────────────┼─────────────────┤
-│ addy osmani   │ 1882996.512818  │
+│ addy osmani   │ 2092282.102868  │
 ├───────────────┼─────────────────┤
-│ fast-memoize  │ 1431840.065495  │
+│ fast-memoize  │ 1722392.865214  │
 └───────────────┴─────────────────┘
 Fastest was "micro-memoize".
+
 ```
 
 ## Support

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1392,8 +1392,28 @@ describe('cache invalidation integrity', () => {
     expect(memoized.cache.snapshot.keys).toEqual([[2], [1]]);
   });
 
-  test('releases the neighbors of a node removed from cache', () => {
+  test('releases the neighbors of a deleted node', () => {
     const memoized = memoize((value: number) => value, { maxSize: 3 });
+
+    memoized(1);
+    memoized(2);
+    memoized(3);
+
+    const deleted = memoized.cache.h!;
+
+    memoized.cache.delete([3]);
+
+    // Holding a deleted node must not hold the rest of the list alive with it.
+    expect(deleted.n).toBeUndefined();
+    expect(deleted.p).toBeUndefined();
+    expect(deleted.r).toBe(true);
+  });
+
+  test('releases the neighbors on clear when a node can outlive the cache', () => {
+    // An async cache hands node references to its promise handlers, so a cleared node can
+    // still be reached and has to be marked and unlinked. A synchronous cache with nothing
+    // listening drops the whole graph at once and skips that walk.
+    const memoized = memoize((value: number) => Promise.resolve(value), { async: true, maxSize: 3 });
 
     memoized(1);
     memoized(2);
@@ -1402,13 +1422,51 @@ describe('cache invalidation integrity', () => {
     const head = memoized.cache.h!;
     const tail = memoized.cache.t!;
 
-    memoized.cache.delete([3]);
     memoized.cache.clear();
 
     expect(head.n).toBeUndefined();
     expect(head.p).toBeUndefined();
+    expect(head.r).toBe(true);
     expect(tail.n).toBeUndefined();
     expect(tail.p).toBeUndefined();
+    expect(tail.r).toBe(true);
+  });
+
+  test('clears a synchronous cache with no listeners', () => {
+    const memoized = memoize((value: number) => value, { maxSize: 3 });
+
+    memoized(1);
+    memoized(2);
+    memoized(3);
+
+    memoized.cache.clear();
+
+    expect(memoized.cache.size).toBe(0);
+    expect(memoized.cache.h).toBeUndefined();
+    expect(memoized.cache.t).toBeUndefined();
+    expect(memoized.cache.snapshot.keys).toEqual([]);
+    expect(memoized.cache.has([1])).toBe(false);
+
+    memoized(4);
+
+    expect(memoized.cache.size).toBe(1);
+    expect(memoized.cache.snapshot.keys).toEqual([[4]]);
+  });
+
+  test('emits a delete for every entry when clearing a single-entry cache', () => {
+    const memoized = memoize((value: number) => value);
+    const deleteSpy = vi.fn();
+
+    memoized.cache.on('delete', deleteSpy);
+
+    memoized(1);
+    memoized.cache.clear();
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy.mock.calls[0]![0]).toMatchObject({ key: [1], reason: 'explicit clear', type: 'delete' });
+    expect(memoized.cache.size).toBe(0);
+    expect(memoized.cache.h).toBeUndefined();
+    expect(memoized.cache.t).toBeUndefined();
   });
 });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1411,3 +1411,102 @@ describe('cache invalidation integrity', () => {
     expect(tail.p).toBeUndefined();
   });
 });
+
+describe('single-entry cache fast path', () => {
+  test('emits the eviction before the addition when replacing the only entry', () => {
+    const memoized = memoize((value: number) => value);
+    const events: string[] = [];
+
+    memoized.cache.on('add', ({ key, reason }) => {
+      events.push(`add:${String(key[0])}:${String(reason)}`);
+    });
+    memoized.cache.on('delete', ({ key, reason }) => {
+      events.push(`delete:${String(key[0])}:${String(reason)}`);
+    });
+
+    memoized(1);
+    memoized(2);
+
+    expect(events).toEqual(['add:1:undefined', 'delete:1:evicted', 'add:2:undefined']);
+    expect(memoized.cache.size).toBe(1);
+    expect(memoized.cache.snapshot.keys).toEqual([[2]]);
+  });
+
+  test('keeps head, tail and size consistent across repeated replacement', () => {
+    const memoized = memoize((value: number) => value * 2);
+
+    for (let index = 0; index < 5; ++index) {
+      expect(memoized(index)).toBe(index * 2);
+      expect(memoized.cache.size).toBe(1);
+      expect(memoized.cache.h).toBe(memoized.cache.t);
+      expect(memoized.cache.h!.n).toBeUndefined();
+      expect(memoized.cache.h!.p).toBeUndefined();
+    }
+
+    expect(memoized.cache.snapshot).toEqual({
+      entries: [[[4], 8]],
+      keys: [[4]],
+      size: 1,
+      values: [8],
+    });
+  });
+
+  test('still supports the general cache methods after the fast path has run', () => {
+    const memoized = memoize((value: number) => value);
+
+    memoized(1);
+    memoized(2);
+
+    memoized.cache.set([3], 30);
+
+    expect(memoized.cache.size).toBe(1);
+    expect(memoized.cache.get([3])).toBe(30);
+
+    expect(memoized.cache.delete([3])).toBe(true);
+    expect(memoized.cache.size).toBe(0);
+    expect(memoized.cache.h).toBeUndefined();
+    expect(memoized.cache.t).toBeUndefined();
+
+    expect(memoized(4)).toBe(4);
+    expect(memoized.cache.size).toBe(1);
+
+    memoized.cache.clear();
+
+    expect(memoized.cache.size).toBe(0);
+    expect(memoized.cache.snapshot.keys).toEqual([]);
+  });
+
+  test('removes the only entry when its promise rejects', async () => {
+    const memoized = memoize((value: number) => Promise.reject(new Error(`nope ${value}`)), { async: true });
+
+    await expect(memoized(1)).rejects.toThrow('nope 1');
+
+    expect(memoized.cache.size).toBe(0);
+    expect(memoized.cache.h).toBeUndefined();
+    expect(memoized.cache.t).toBeUndefined();
+  });
+
+  test('does not remove a replacement entry when the entry it replaced rejects', async () => {
+    const rejects: Array<(error: Error) => void> = [];
+    const memoized = memoize(
+      (_value: number) =>
+        new Promise((_resolve, reject) => {
+          rejects.push(reject);
+        }),
+      { async: true },
+    );
+
+    const first = memoized(1);
+    first.catch(() => undefined);
+
+    memoized(2).catch(() => undefined);
+
+    // `1` was evicted by `2`; its rejection must not disturb the entry now held.
+    rejects[0]!(new Error('nope'));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(memoized.cache.size).toBe(1);
+    expect(memoized.cache.snapshot.keys).toEqual([[2]]);
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1313,3 +1313,101 @@ describe('cache mutation methods', () => {
     expect(persistentHitSpy).toHaveBeenCalledTimes(4);
   });
 });
+
+describe('cache invalidation integrity', () => {
+  test('does not restore cleared entries when an async entry rejects after the clear', async () => {
+    const rejects: Array<(error: Error) => void> = [];
+    const memoized = memoize(
+      (_value: number) =>
+        new Promise((_resolve, reject) => {
+          rejects.push(reject);
+        }),
+      { async: true, maxSize: 5 },
+    );
+
+    [1, 2, 3].forEach((value) => {
+      memoized(value).catch(() => undefined);
+    });
+
+    expect(memoized.cache.size).toBe(3);
+
+    memoized.cache.clear();
+
+    expect(memoized.cache.size).toBe(0);
+
+    // Reject the node that was the head of the list; before it was marked as removed, its
+    // stale `n` pointer would be reinstated as the head of the cache.
+    rejects[2]!(new Error('rejected'));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(memoized.cache.size).toBe(0);
+    expect(memoized.cache.snapshot.keys).toEqual([]);
+    expect(memoized.cache.has([1])).toBe(false);
+    expect(memoized.cache.has([2])).toBe(false);
+  });
+
+  test('does not notify of an update when an async entry resolves after the clear', async () => {
+    let resolvePending: (value: number) => void = () => undefined;
+
+    const memoized = memoize(
+      (_value: number) =>
+        new Promise((resolve) => {
+          resolvePending = resolve;
+        }),
+      { async: true },
+    );
+
+    const pending = memoized(1);
+
+    const updateSpy = vi.fn();
+    memoized.cache.on('update', updateSpy);
+
+    memoized.cache.clear();
+
+    resolvePending(1);
+
+    await pending;
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(memoized.cache.size).toBe(0);
+  });
+
+  test('ignores a repeated delete of the same node', () => {
+    const memoized = memoize((value: number) => value, { maxSize: 3 });
+
+    memoized(1);
+    memoized(2);
+    memoized(3);
+
+    const node = memoized.cache.h!;
+
+    memoized.cache.d(node, 'first');
+
+    expect(memoized.cache.size).toBe(2);
+
+    memoized.cache.d(node, 'second');
+
+    expect(memoized.cache.size).toBe(2);
+    expect(memoized.cache.snapshot.keys).toEqual([[2], [1]]);
+  });
+
+  test('releases the neighbors of a node removed from cache', () => {
+    const memoized = memoize((value: number) => value, { maxSize: 3 });
+
+    memoized(1);
+    memoized(2);
+    memoized(3);
+
+    const head = memoized.cache.h!;
+    const tail = memoized.cache.t!;
+
+    memoized.cache.delete([3]);
+    memoized.cache.clear();
+
+    expect(head.n).toBeUndefined();
+    expect(head.p).toBeUndefined();
+    expect(tail.n).toBeUndefined();
+    expect(tail.p).toBeUndefined();
+  });
+});

--- a/__tests__/stats.test.ts
+++ b/__tests__/stats.test.ts
@@ -61,6 +61,8 @@ describe('statsName', () => {
       name: statsName,
       usage: '0.0000%',
     });
+
+    profiled.statsManager!.dispose();
   });
 
   test('should handle collecting more stats after clearing', () => {
@@ -95,6 +97,8 @@ describe('statsName', () => {
       name: statsName,
       usage: '100.0000%',
     });
+
+    profiled.statsManager!.dispose();
   });
 });
 
@@ -140,10 +144,128 @@ describe('getStats', () => {
 
     clearStats();
 
+    // The counts are reset, but the profile remains registered and continues collecting,
+    // matching the behavior of `clearStats(statsName)`.
     expect(getStats()).toEqual({
       calls: 0,
       hits: 0,
-      profiles: {},
+      profiles: {
+        [statsName]: {
+          calls: 0,
+          hits: 0,
+          name: statsName,
+          usage: '0.0000%',
+        },
+      },
+      usage: '0.0000%',
+    });
+
+    profiled(foo, bar);
+    profiled(foo, bar);
+
+    expect(getStats(statsName)).toEqual({
+      calls: 2,
+      hits: 2,
+      name: statsName,
+      usage: '100.0000%',
+    });
+
+    profiled.statsManager!.dispose();
+  });
+
+  test('should keep collecting into a profile after a global clear', () => {
+    const statsName = 'globalClear';
+    const profiled = memoize(method, { statsName });
+
+    profiled(foo, bar);
+    profiled(foo, bar);
+    profiled(foo, 'baz');
+
+    expect(getStats(statsName)).toEqual({
+      calls: 3,
+      hits: 1,
+      name: statsName,
+      usage: '33.3333%',
+    });
+
+    clearStats();
+
+    profiled(foo, 'baz');
+    profiled(foo, 'baz');
+
+    expect(getStats(statsName)).toEqual({
+      calls: 2,
+      hits: 2,
+      name: statsName,
+      usage: '100.0000%',
+    });
+
+    expect(getStats()!.profiles[statsName]).toEqual({
+      calls: 2,
+      hits: 2,
+      name: statsName,
+      usage: '100.0000%',
+    });
+
+    profiled.statsManager!.dispose();
+  });
+
+  test('should number a profile whose statsName is already taken', () => {
+    const statsName = 'shared';
+    const first = memoize(method, { statsName });
+    const second = memoize(method, { statsName });
+    const third = memoize(method, { statsName });
+
+    // Two methods asking for one name are still two methods, so each keeps its own profile.
+    expect(first.statsManager!.n).toBe('shared');
+    expect(second.statsManager!.n).toBe('shared (2)');
+    expect(third.statsManager!.n).toBe('shared (3)');
+
+    first(foo, bar);
+    first(foo, bar);
+    second(foo, bar);
+
+    expect(getStats('shared')).toEqual({ calls: 2, hits: 1, name: 'shared', usage: '50.0000%' });
+    expect(getStats('shared (2)')).toEqual({ calls: 1, hits: 0, name: 'shared (2)', usage: '0.0000%' });
+    expect(getStats('shared (3)')).toEqual({ calls: 0, hits: 0, name: 'shared (3)', usage: '0.0000%' });
+
+    first.statsManager!.dispose();
+    second.statsManager!.dispose();
+    third.statsManager!.dispose();
+  });
+
+  test('should reuse a name once the profile holding it is disposed', () => {
+    const first = memoize(method, { statsName: 'reused' });
+
+    expect(first.statsManager!.n).toBe('reused');
+
+    first.statsManager!.dispose();
+
+    const second = memoize(method, { statsName: 'reused' });
+
+    expect(second.statsManager!.n).toBe('reused');
+
+    second.statsManager!.dispose();
+  });
+
+  test('should remove a disposed profile from the registry and stop collecting', () => {
+    const statsName = 'disposed';
+    const profiled = memoize(method, { statsName });
+
+    profiled(foo, bar);
+    profiled(foo, bar);
+
+    expect(getStats()!.profiles[statsName]).toBeDefined();
+
+    profiled.statsManager!.dispose();
+
+    profiled(foo, bar);
+
+    expect(getStats()!.profiles[statsName]).toBeUndefined();
+    expect(getStats(statsName)).toEqual({
+      calls: 0,
+      hits: 0,
+      name: statsName,
       usage: '0.0000%',
     });
   });

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,18 @@ declare class Cache<Fn extends (...args: any[]) => any> {
      * entry if it rejects.
      */
     w(node: CacheNode<Fn>): ReturnType<Fn>;
+    /**
+     * Method to create a new node for a single-entry cache, the default and most common
+     * configuration.
+     *
+     * A cache of this si[z]e is never a list: there is nothing to link the new node to, nothing
+     * to count, and the entry it replaces can be evicted outright instead of being spliced out.
+     *
+     * @NOTE
+     * This leaves the cache in the same shape a single-entry list would have, so the general
+     * methods (`set`, `delete`, `clear`) continue to operate on it correctly.
+     */
+    z(key: Key, value: ReturnType<Fn>, reason?: string): CacheNode<Fn>;
 }
 
 declare class ExpirationManager<Fn extends (...args: any[]) => any> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -187,9 +187,12 @@ declare class StatsManager<Fn extends (...args: any[]) => any> {
     p: ProfileCounts;
     constructor(cache: Cache<Fn>, statsName: string);
     /**
-     * Method to compute the [m]etrics for the profile stats.
+     * Stop collecting stats for this profile and remove it from the stats registry.
+     *
+     * Profiles are held for the lifetime of the process otherwise, so this is required to
+     * release a memoized method (and everything its cache retains) when it is no longer used.
      */
-    m(): ProfileStats;
+    dispose(): void;
     /**
      * Method to [r]eset the counts.
      */
@@ -202,6 +205,10 @@ declare class StatsManager<Fn extends (...args: any[]) => any> {
 /**
  * Clear all existing stats stored, either of the specific profile whose name is passed,
  * or globally if no name is passed.
+ *
+ * @NOTE
+ * This resets the counts collected; the profiles themselves remain registered and continue
+ * collecting. Use `memoized.statsManager.dispose()` to remove a profile entirely.
  */
 declare function clearStats(statsName?: string): void;
 /**

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -92,23 +92,27 @@ export class Cache<Fn extends (...args: any[]) => any> {
    * Clear the cache.
    */
   clear(reason = 'explicit clear'): void {
-    if (!this.h) {
+    let node: CacheNode<Fn> | undefined = this.h;
+
+    if (!node) {
       return;
     }
 
     const emitter = this.o;
+    const nodes: Array<CacheNode<Fn>> | undefined = emitter ? [] : undefined;
 
-    let nodes: Array<CacheNode<Fn>> | undefined;
+    // Each node must be marked as [r]emoved and unlinked from its neighbors, otherwise any
+    // deferred operation still holding a reference to it (an async entry that settles after
+    // the clear, for example) can rewire the discarded list back into the cache.
+    while (node != null) {
+      const next: CacheNode<Fn> | undefined = node.n;
 
-    if (emitter) {
-      nodes = [];
+      node.n = node.p = undefined;
+      node.r = true;
 
-      let node: CacheNode<Fn> | undefined = this.h;
+      nodes && nodes.push(node);
 
-      while (node != null) {
-        nodes.push(node);
-        node = node.n;
-      }
+      node = next;
     }
 
     this.h = this.t = undefined;
@@ -205,6 +209,12 @@ export class Cache<Fn extends (...args: any[]) => any> {
    * Method to [d]elete the given `node` from the cache.
    */
   d(node: CacheNode<Fn>, reason: string): void {
+    if (node.r) {
+      // Already removed from cache; re-running the unlink against its stale neighbors would
+      // corrupt the list and drive the count below zero.
+      return;
+    }
+
     const next = node.n;
     const prev = node.p;
 
@@ -222,6 +232,7 @@ export class Cache<Fn extends (...args: any[]) => any> {
 
     --this.c;
 
+    node.n = node.p = undefined;
     node.r = true;
 
     this.o && this.o.n('delete', node, reason);

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -99,6 +99,30 @@ export class Cache<Fn extends (...args: any[]) => any> {
     }
 
     const emitter = this.o;
+
+    // The walk below exists only so that a node can recognize itself as removed later. The
+    // handlers attached in `w` are the only thing that holds a node beyond the call that
+    // created it, so a synchronous cache with nothing listening can never see one of these
+    // nodes again, and the entries can simply be dropped.
+    if (!emitter && !this.p) {
+      this.h = this.t = undefined;
+      this.c = 0;
+
+      return;
+    }
+
+    if (this.s === 1) {
+      // A single-entry cache holds no list to walk.
+      this.h = this.t = undefined;
+      this.c = 0;
+
+      node.r = true;
+
+      emitter && emitter.n('delete', node, reason);
+
+      return;
+    }
+
     const nodes: Array<CacheNode<Fn>> | undefined = emitter ? [] : undefined;
 
     // Each node must be marked as [r]emoved and unlinked from its neighbors, otherwise any

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -360,6 +360,39 @@ export class Cache<Fn extends (...args: any[]) => any> {
       },
     );
   }
+
+  /**
+   * Method to create a new node for a single-entry cache, the default and most common
+   * configuration.
+   *
+   * A cache of this si[z]e is never a list: there is nothing to link the new node to, nothing
+   * to count, and the entry it replaces can be evicted outright instead of being spliced out.
+   *
+   * @NOTE
+   * This leaves the cache in the same shape a single-entry list would have, so the general
+   * methods (`set`, `delete`, `clear`) continue to operate on it correctly.
+   */
+  z(key: Key, value: ReturnType<Fn>, reason?: string): CacheNode<Fn> {
+    const prevHead = this.h;
+    const node = { k: key, n: undefined, p: undefined, v: value };
+
+    if (this.p) {
+      node.v = this.w(node);
+    }
+
+    this.h = this.t = node;
+    this.c = 1;
+
+    if (prevHead) {
+      prevHead.r = true;
+
+      this.o && this.o.n('delete', prevHead, 'evicted');
+    }
+
+    this.o && this.o.n('add', node, reason);
+
+    return node;
+  }
 }
 
 function getIsKeyEqual<Fn extends (...args: any[]) => any>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,21 +38,40 @@ function createMemoizedMethod<Fn extends (...args: any) => any, Opts extends Opt
   cache: Cache<Fn>,
   forceUpdate: Opts['forceUpdate'],
 ): Memoized<Fn, Opts> {
-  const memoized = function memoized(this: any, ...args: Parameters<Fn>): ReturnType<Fn> {
-    const key: Key = cache.k ? cache.k(args) : args;
+  // A single-entry cache is the default and by far the most common configuration, and it has
+  // no list to search or reorder: the only entry held is either the one requested or the one
+  // being replaced. Specializing it here skips the search in `cache.g`, the recency update in
+  // `cache.u`, and the size bookkeeping in `cache.n` entirely.
+  const memoized = (
+    cache.s === 1
+      ? function memoized(this: any, ...args: Parameters<Fn>): ReturnType<Fn> {
+          const key: Key = cache.k ? cache.k(args) : args;
+          const node = cache.h;
 
-    let node = cache.g(key);
+          if (node && cache.e(node.k, key)) {
+            cache.o && cache.o.n('hit', node);
 
-    if (!node) {
-      node = cache.n(key, fn.apply(this, args) as ReturnType<Fn>);
-    } else if (node !== cache.h) {
-      cache.u(node, undefined, true);
-    } else if (cache.o) {
-      cache.o.n('hit', node);
-    }
+            return node.v;
+          }
 
-    return node.v;
-  } as Memoized<Fn, Opts>;
+          return cache.z(key, fn.apply(this, args) as ReturnType<Fn>).v;
+        }
+      : function memoized(this: any, ...args: Parameters<Fn>): ReturnType<Fn> {
+          const key: Key = cache.k ? cache.k(args) : args;
+
+          let node = cache.g(key);
+
+          if (!node) {
+            node = cache.n(key, fn.apply(this, args) as ReturnType<Fn>);
+          } else if (node !== cache.h) {
+            cache.u(node, undefined, true);
+          } else if (cache.o) {
+            cache.o.n('hit', node);
+          }
+
+          return node.v;
+        }
+  ) as Memoized<Fn, Opts>;
 
   if (!forceUpdate) {
     return memoized;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -6,6 +6,9 @@ interface ProfileCounts {
   h: number;
 }
 
+/**
+ * Registry of every live profile, keyed by its resolved name.
+ */
 const nameToProfile = new Map<string, StatsManager<any>>();
 
 let active = false;
@@ -30,9 +33,11 @@ export class StatsManager<Fn extends (...args: any[]) => any> {
 
   constructor(cache: Cache<Fn>, statsName: string) {
     this.c = cache;
-    this.n = statsName;
+    // Two memoized methods asking for the same name are still two separate methods, so the
+    // later one is numbered rather than replacing the profile of the earlier.
+    this.n = getAvailableName(statsName);
 
-    nameToProfile.set(statsName, this);
+    nameToProfile.set(this.n, this);
 
     if (active) {
       this.s();
@@ -40,13 +45,15 @@ export class StatsManager<Fn extends (...args: any[]) => any> {
   }
 
   /**
-   * Method to compute the [m]etrics for the profile stats.
+   * Stop collecting stats for this profile and remove it from the stats registry.
+   *
+   * Profiles are held for the lifetime of the process otherwise, so this is required to
+   * release a memoized method (and everything its cache retains) when it is no longer used.
    */
-  m(): ProfileStats {
-    const { c: calls, h: hits } = this.p;
-    const usage = calls ? `${((hits / calls) * 100).toFixed(4)}%` : '0.0000%';
+  dispose(): void {
+    this.d?.();
 
-    return { calls, hits, name: this.n, usage };
+    nameToProfile.delete(this.n);
   }
 
   /**
@@ -85,20 +92,22 @@ export class StatsManager<Fn extends (...args: any[]) => any> {
 /**
  * Clear all existing stats stored, either of the specific profile whose name is passed,
  * or globally if no name is passed.
+ *
+ * @NOTE
+ * This resets the counts collected; the profiles themselves remain registered and continue
+ * collecting. Use `memoized.statsManager.dispose()` to remove a profile entirely.
  */
 export function clearStats(statsName?: string) {
   if (!active) {
     return;
   }
 
-  if (statsName) {
-    const statsManager = nameToProfile.get(statsName);
-
-    if (statsManager) {
-      statsManager.r();
-    }
+  if (statsName != null) {
+    nameToProfile.get(statsName)?.r();
   } else {
-    nameToProfile.clear();
+    nameToProfile.forEach((profile) => {
+      profile.r();
+    });
   }
 }
 
@@ -114,18 +123,8 @@ export function getStats<Name extends string | undefined>(
   }
 
   if (statsName != null) {
-    const statsManager = nameToProfile.get(statsName);
-
-    const profileStats: ProfileStats = statsManager?.p.c
-      ? statsManager.m()
-      : {
-          calls: 0,
-          hits: 0,
-          name: statsName,
-          usage: getUsagePercentage(0, 0),
-        };
     // @ts-expect-error - Conditional returns can be tricky.
-    return profileStats;
+    return getProfileStats(statsName, nameToProfile.get(statsName));
   }
 
   let calls = 0;
@@ -133,11 +132,13 @@ export function getStats<Name extends string | undefined>(
 
   const profiles: Record<string, ProfileStats> = {};
 
-  nameToProfile.forEach((profile, statsName) => {
-    profiles[statsName] = profile.m();
+  nameToProfile.forEach((profile, name) => {
+    const profileStats = getProfileStats(name, profile);
 
-    calls += profile.p.c;
-    hits += profile.p.h;
+    profiles[name] = profileStats;
+
+    calls += profileStats.calls;
+    hits += profileStats.hits;
   });
 
   const globalStats: GlobalStats = {
@@ -149,6 +150,30 @@ export function getStats<Name extends string | undefined>(
 
   // @ts-expect-error - Conditional returns can be tricky.
   return globalStats;
+}
+
+/**
+ * Get a name not already in use, numbering the one requested when it is taken.
+ */
+function getAvailableName(statsName: string): string {
+  let name = statsName;
+  let count = 1;
+
+  while (nameToProfile.has(name)) {
+    name = `${statsName} (${String(++count)})`;
+  }
+
+  return name;
+}
+
+/**
+ * Get the stats for the given profile.
+ */
+function getProfileStats(name: string, profile: StatsManager<any> | undefined): ProfileStats {
+  const calls = profile ? profile.p.c : 0;
+  const hits = profile ? profile.p.h : 0;
+
+  return { calls, hits, name, usage: getUsagePercentage(calls, hits) };
 }
 
 /**


### PR DESCRIPTION
## Reason for change

I did an audit with Claude, and identified a few correctness issues related to clearance of entries and stats collection. While working, some performance improvements were also discovered.

## Change

### Correctness

- Ensure clearing entries when an `async` entry rejects does not accidentally restore the entries
- `clearStats()` no longer accidentally unregisters profiles
- Using the same `statsName` no longer silently clobbers existing entries

### Enhancements

- Specialized handling of the default `maxSize: 1` use-case for better performance
- No walking of the cache on `.clear()`
- Added `.dispose()` method to the stats manager, to deregister and release the cache